### PR TITLE
Allow the caller to disable docker provider

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -22,8 +22,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/spf13/pflag"
 	"k8s.io/klog/v2"
 )
+
+var flagDisableDockerProvider = pflag.Bool("disable-docker-provider", false,
+	"Disables the docker provider")
 
 // DockerConfigProvider is the interface that registered extensions implement
 // to materialize 'dockercfg' credentials.
@@ -70,6 +74,10 @@ type CachingDockerConfigProvider struct {
 
 // Enabled implements dockerConfigProvider
 func (d *defaultDockerConfigProvider) Enabled() bool {
+	if *flagDisableDockerProvider {
+		return false
+	}
+
 	return true
 }
 

--- a/provider_test.go
+++ b/provider_test.go
@@ -19,6 +19,8 @@ package credentialprovider
 import (
 	"testing"
 	"time"
+
+	"github.com/spf13/pflag"
 )
 
 type testProvider struct {
@@ -76,4 +78,35 @@ func TestCachingProvider(t *testing.T) {
 	if provider.Count != 3 {
 		t.Errorf("Unexpected number of Provide calls: %v", provider.Count)
 	}
+}
+
+func TestCachingDockerConfigProvider_Enabled(t *testing.T) {
+	err := pflag.CommandLine.Parse([]string{})
+	if err != nil {
+		t.Errorf("Unexpected parsing error: %s", err)
+	}
+
+	provider := &CachingDockerConfigProvider{
+		Provider: &defaultDockerConfigProvider{},
+		Lifetime: 5 * time.Minute,
+	}
+
+	if !provider.Enabled() {
+		t.Errorf("Expected provider to be enabled, but it was disabledr")
+	}
+
+	err = pflag.CommandLine.Parse([]string{"--disable-docker-provider"})
+	if err != nil {
+		t.Errorf("Unexpected parsing error: %s", err)
+	}
+
+	provider = &CachingDockerConfigProvider{
+		Provider: &defaultDockerConfigProvider{},
+		Lifetime: 5 * time.Minute,
+	}
+
+	if provider.Enabled() {
+		t.Errorf("Expected provider to be disabled, but it was enabled")
+	}
+
 }


### PR DESCRIPTION
There are some tools, like [imgpkg](https://carvel.dev/imgpkg) that can be used inside a Kubernetes cluster and also in local machines, having the docker config provider can be an issue.
In the local case sometimes to authenticate with registries like gcr or azure there is a need to talk with cred helpers, but this provider doesn't support them.

This change will enable us (carvel) to use this library in both situations. As a workaround, we added a git patch on our vendor folder to disable the provider which is not great.